### PR TITLE
fix: Disable refresh due to a TF bug

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,18 +16,12 @@ builds:
     ldflags:
       - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
     goos:
-      - freebsd
       - windows
       - linux
       - darwin
     goarch:
       - amd64
-      - '386'
-      - arm
       - arm64
-    ignore:
-      - goos: darwin
-        goarch: '386'
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -418,40 +418,6 @@ func resourceRelease() *schema.Resource {
 }
 
 func resourceReleaseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	exists, err := resourceReleaseExists(d, meta)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	if !exists {
-		d.SetId("")
-		return diag.Diagnostics{}
-	}
-
-	logID := fmt.Sprintf("[resourceReleaseRead: %s]", d.Get("name").(string))
-	debug("%s Started", logID)
-
-	m := meta.(*Meta)
-	n := d.Get("namespace").(string)
-
-	c, err := m.GetHelmConfiguration(d, n)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	name := d.Get("name").(string)
-	r, err := getRelease(m, c, name)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	err = setReleaseAttributes(d, r, m)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	debug("%s Done", logID)
-
 	return nil
 }
 


### PR DESCRIPTION
Unfortunately during refresh phase we only get state data. Therefore we're unable to configure Kubernetes API client properly. 

Disable data refresh for now, update/delete and create should still work properly but detection of changes made by external sources won't work.